### PR TITLE
Negative tests

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/src/test/java/DataModels/ErrorResponse.java
+++ b/src/test/java/DataModels/ErrorResponse.java
@@ -1,0 +1,44 @@
+package DataModels;
+
+import java.io.Serializable;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class ErrorResponse implements Serializable
+{
+
+    @SerializedName("title")
+    @Expose
+    private String title;
+    @SerializedName("status")
+    @Expose
+    private Integer status;
+
+    private final static long serialVersionUID = -5377087527975957652L;
+
+    public ErrorResponse() {
+    }
+
+    public ErrorResponse(String title, Integer status) {
+        super();
+        this.title = title;
+        this.status = status;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+}

--- a/src/test/java/DataModels/InvalidParamsBooksRequest.java
+++ b/src/test/java/DataModels/InvalidParamsBooksRequest.java
@@ -1,0 +1,91 @@
+package DataModels;
+
+import java.io.Serializable;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class InvalidParamsBooksRequest implements Serializable
+{
+
+    @SerializedName("id")
+    @Expose
+    private Integer id;
+    @SerializedName("title")
+    @Expose
+    private Integer title;
+    @SerializedName("description")
+    @Expose
+    private String description;
+    @SerializedName("pageCount")
+    @Expose
+    private Integer pageCount;
+    @SerializedName("excerpt")
+    @Expose
+    private String excerpt;
+    @SerializedName("publishDate")
+    @Expose
+    private String publishDate;
+    private final static long serialVersionUID = 1528647374608478115L;
+
+    public InvalidParamsBooksRequest() {
+    }
+
+    public InvalidParamsBooksRequest(Integer id, Integer title, String description, Integer pageCount, String excerpt, String publishDate) {
+        super();
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.pageCount = pageCount;
+        this.excerpt = excerpt;
+        this.publishDate = publishDate;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getTitle() {
+        return title;
+    }
+
+    public void setTitle(Integer title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Integer getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(Integer pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public String getExcerpt() {
+        return excerpt;
+    }
+
+    public void setExcerpt(String excerpt) {
+        this.excerpt = excerpt;
+    }
+
+    public String getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(String publishDate) {
+        this.publishDate = publishDate;
+    }
+
+}

--- a/src/test/java/DataModels/InvalidParamsUsersRequest.java
+++ b/src/test/java/DataModels/InvalidParamsUsersRequest.java
@@ -1,0 +1,55 @@
+package DataModels;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+
+public class InvalidParamsUsersRequest implements Serializable {
+
+    @SerializedName("id")
+    @Expose
+    private Integer id;
+
+    @SerializedName("userName")
+    @Expose
+    private Integer userName;
+
+    @SerializedName("password")
+    @Expose
+    private String password;
+
+    private final static long serialVersionUID = 1528647374608478116L;
+
+    public InvalidParamsUsersRequest() {}
+
+    public InvalidParamsUsersRequest(Integer id, Integer userName, String password) {
+        this.id = id;
+        this.userName = userName;
+        this.password = password;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getUserName() {
+        return userName;
+    }
+
+    public void setUserName(Integer userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/test/java/calls/BooksApi.java
+++ b/src/test/java/calls/BooksApi.java
@@ -1,7 +1,6 @@
 package calls;
 
-import DataModels.BooksRequest;
-import DataModels.BooksResponse;
+import DataModels.*;
 import com.google.gson.GsonBuilder;
 import common.GsonFunctions;
 import common.RestAssuredFunctions;
@@ -38,4 +37,18 @@ public class BooksApi {
         Response response = RestAssuredFunctions.getById(ApiEndpoints.BOOKS, id);
         return GsonFunctions.parseSuccessResponseToModel(response, BooksResponse.class);
     }
+
+    public static ErrorResponse getBookWithError(Integer Id){
+        return GsonFunctions.parseErrorResponseToModel(RestAssuredFunctions.getById(ApiEndpoints.BOOKS, Id), ErrorResponse.class);
+    }
+
+    public static ErrorResponse createBookError(InvalidParamsBooksRequest booksRequest){
+        String jsonPayload = new GsonBuilder().setPrettyPrinting().create().toJson(booksRequest);
+        System.out.println("Sending JSON payload:\n" + jsonPayload);
+
+        return GsonFunctions.parseErrorResponseToModel(RestAssuredFunctions.post(ApiEndpoints.BOOKS, booksRequest), ErrorResponse.class);
+    }
+
+
+
 }

--- a/src/test/java/calls/UsersApi.java
+++ b/src/test/java/calls/UsersApi.java
@@ -1,5 +1,7 @@
 package calls;
 
+import DataModels.ErrorResponse;
+import DataModels.InvalidParamsUsersRequest;
 import DataModels.UsersRequest;
 import DataModels.UsersResponse;
 import com.google.gson.GsonBuilder;
@@ -41,5 +43,23 @@ public class UsersApi {
     public static UsersResponse getUserById(int id) {
         Response response = RestAssuredFunctions.getById(ApiEndpoints.USERS, id);
         return GsonFunctions.parseSuccessResponseToModel(response, UsersResponse.class);
+    }
+
+    public static ErrorResponse getUserWithError(Integer Id){
+        return GsonFunctions.parseErrorResponseToModel(RestAssuredFunctions.getById(ApiEndpoints.USERS, Id), ErrorResponse.class);
+    }
+
+    public static ErrorResponse createUserWithInvalidParams(InvalidParamsUsersRequest usersRequest){
+        String jsonPayload = new GsonBuilder().setPrettyPrinting().create().toJson(usersRequest);
+        System.out.println("Sending JSON payload:\n" + jsonPayload);
+
+        return GsonFunctions.parseErrorResponseToModel(RestAssuredFunctions.post(ApiEndpoints.USERS, usersRequest), ErrorResponse.class);
+    }
+
+    public static ErrorResponse updateErrorUser(InvalidParamsUsersRequest putUser) {
+        return GsonFunctions.parseErrorResponseToModel(
+                RestAssuredFunctions.put(ApiEndpoints.USERS, putUser.getId(), putUser),
+                ErrorResponse.class
+        );
     }
 }

--- a/src/test/java/common/GsonFunctions.java
+++ b/src/test/java/common/GsonFunctions.java
@@ -29,4 +29,21 @@ public class GsonFunctions {
         return null;
     }
 
+    public static <T> T parseErrorResponseToModel(Response jsonResponse, Class<T> classOfT){
+        String json = jsonResponse.body().asString();
+        String prettyJsonString="";
+        try {
+            prettyJsonString = new GsonBuilder().setPrettyPrinting().create().toJson(new JsonParser().parse(json));
+            if(jsonResponse.getStatusCode() < 400) {
+                Assert.fail("Endpoint for processing class "+ classOfT+"didn'treturn error: "+ "data["+prettyJsonString+"]");
+            } else {
+                return new Gson().fromJson(prettyJsonString, (Type) classOfT);
+            }
+        }
+        catch (IllegalStateException | JsonSyntaxException exception) {
+            Assert.fail("Detailed message: "+exception.getMessage()+ ", Invalid json format " + prettyJsonString + " for processing class" + classOfT);
+        }
+        return null;
+    }
+
 }

--- a/src/test/java/constants/ErrorMessages.java
+++ b/src/test/java/constants/ErrorMessages.java
@@ -1,0 +1,8 @@
+package constants;
+
+public class ErrorMessages {
+    public static final String FORBIDDEN = "Forbidden";
+    public static final String NOT_FOUND = "Not Found";
+    public static final String NULL="null";
+    public static final String VALIDATION="One or more validation errors occurred.";
+}

--- a/src/test/java/test/asserts/CommonErrorAssert.java
+++ b/src/test/java/test/asserts/CommonErrorAssert.java
@@ -1,0 +1,16 @@
+package test.asserts;
+
+import DataModels.ErrorResponse;
+import org.testng.asserts.SoftAssert;
+
+public class CommonErrorAssert {
+    private SoftAssert softAssert;
+
+    public CommonErrorAssert() {this.softAssert = new SoftAssert();}
+
+    public void assertBookErrorResponse(ErrorResponse actualError, ErrorResponse expectedError) {
+        this.softAssert.assertEquals(actualError.getTitle(), expectedError.getTitle(), "Title didn't match");
+        this.softAssert.assertEquals(actualError.getStatus(), expectedError.getStatus(), "Status didn't match");
+        this.softAssert.assertAll();
+    }
+}

--- a/src/test/java/test/suites/BooksSecurityTests.java
+++ b/src/test/java/test/suites/BooksSecurityTests.java
@@ -1,0 +1,50 @@
+package test.suites;
+
+import DataModels.ErrorResponse;
+import DataModels.BooksRequest;
+import DataModels.InvalidParamsBooksRequest;
+import calls.BooksApi;
+import constants.ErrorMessages;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import test.asserts.BooksAsserts;
+import test.asserts.CommonErrorAssert;
+import test.common.TestBase;
+
+public class BooksSecurityTests extends TestBase {
+
+    public BooksAsserts booksAsserts = new BooksAsserts();
+    BooksRequest booksRequest;
+    Integer idOfNewBook;
+
+    @BeforeMethod
+    public void prepareTestData(){
+        booksRequest = new BooksRequest(-1, "Proba", "Proba1", 100, "Nema", "2025-10-06T13:37:13.983Z");
+        idOfNewBook =  BooksApi.postBook(booksRequest).getId();
+    }
+
+    @Test
+    public void verifyCannotGetBook() {
+
+        ErrorResponse actualError = BooksApi.getBookWithError(idOfNewBook);
+
+        CommonErrorAssert commonErrorAssert = new CommonErrorAssert();
+        commonErrorAssert.assertBookErrorResponse(actualError, new ErrorResponse(ErrorMessages.NOT_FOUND, 404));
+    }
+
+    @Test
+    public void verifyDeleteBook() {
+        BooksApi.deleteBook(idOfNewBook);
+        Assert.assertFalse(BooksAsserts.isBookExists(idOfNewBook), "Books is not deleted");
+    }
+
+    @Test
+    public void verifyCreateBookInvalidParams() {
+
+        ErrorResponse actualError = BooksApi.createBookError(new InvalidParamsBooksRequest(1, 1, "", 100, "Nema", "2025-10-06T13:37:13.983Z"));
+
+        CommonErrorAssert commonErrorAssert= new CommonErrorAssert();
+        commonErrorAssert.assertBookErrorResponse(actualError, new ErrorResponse(ErrorMessages.VALIDATION, 400));
+    }
+}

--- a/src/test/java/test/suites/UsersSecurityTests.java
+++ b/src/test/java/test/suites/UsersSecurityTests.java
@@ -1,0 +1,43 @@
+package test.suites;
+
+import DataModels.ErrorResponse;
+import DataModels.UsersRequest;
+import DataModels.InvalidParamsUsersRequest;
+import calls.UsersApi;
+import constants.ErrorMessages;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import test.asserts.UsersAsserts;
+import test.asserts.CommonErrorAssert;
+import test.common.TestBase;
+
+public class UsersSecurityTests extends TestBase {
+
+    public UsersAsserts booksAsserts = new UsersAsserts();
+    UsersRequest usersRequest;
+    Integer idOfNewUser;
+
+    @BeforeMethod
+    public void prepareTestData(){
+        usersRequest = new UsersRequest(-1, "Akica", "Test1");
+        idOfNewUser =  UsersApi.postUser(usersRequest).getId();
+    }
+
+    @Test
+    public void verifyCannotGetUser() {
+
+        ErrorResponse actualError = UsersApi.getUserWithError(idOfNewUser);
+
+        CommonErrorAssert commonErrorAssert = new CommonErrorAssert();
+        commonErrorAssert.assertBookErrorResponse(actualError, new ErrorResponse(ErrorMessages.NOT_FOUND, 404));
+    }
+
+    @Test
+    public void verifyUpdateBookInvalidParams() {
+
+        ErrorResponse actualError = UsersApi.updateErrorUser(new InvalidParamsUsersRequest(1, 2, "Test1"));
+
+        CommonErrorAssert commonErrorAssert= new CommonErrorAssert();
+        commonErrorAssert.assertBookErrorResponse(actualError, new ErrorResponse(ErrorMessages.VALIDATION, 400));
+    }
+}


### PR DESCRIPTION
Negativni testovi koji imaju smisla za naš API:
-Error za kreiranje knjiga sa ne validnim parametrima
-Error Ažuriranje korisnika sa ne validnim parametrima
-Error za brisanje knjige (ovo je više do ne funkcionisanje API)
-Error za dohvatanje korisnika i knjiga po ne validnom Id-u

Napomena: Pošto koristimo fejk api, neke negativne testove poput provere required filed, nije moguće realno sprovesti. API za nevalidne unose vraća generic objedinjen response da negde nešto ne valja. U suštini nažalost ovaj Fake API jednostavno nije dobar za neke kvalitetne testove.